### PR TITLE
Protocol macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["libtransact"]
+members = ["libtransact", "codegen"]

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "codegen"
+version = "0.1.0"
+authors = ["Bitwise IO, Inc."]
+edition = "2018"
+license = "Apache-2.0"
+
+[dependencies]
+syn = { version = "0.15", features = [ "full", "extra-traits", "parsing"] }
+quote = "0.6"
+proc-macro2 = "0.4"
+
+[lib]
+proc-macro = true

--- a/codegen/src/builder.rs
+++ b/codegen/src/builder.rs
@@ -1,0 +1,308 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use syn::{Error as SynError, Lit, Attribute, GenericArgument, PathArguments, Type, Field, Meta, Data, Ident, Fields, DeriveInput};
+use quote::{quote, ToTokens};
+
+pub fn generate_builder_macro(derive_input: DeriveInput) -> TokenStream {
+
+    let struct_impl = match generate_struct_impl(derive_input.clone()) {
+        Ok(tokens) => tokens,
+        Err(err) => {
+            let compile_error = err.to_compile_error();
+            return quote!(#compile_error).into();
+        }
+    };
+
+    let builder_struct = match generate_builder_struct(derive_input.clone()) {
+        Ok(tokens) => tokens,
+        Err(err) => {
+            let compile_error = err.to_compile_error();
+            return quote!(#compile_error).into();
+        }
+    };
+
+    return quote! {
+        #struct_impl
+        #builder_struct
+    }.into();
+}
+
+fn generate_struct_impl(derive_input: DeriveInput) -> Result<TokenStream2, SynError> {
+    let struct_name = derive_input.ident.clone();
+    let getters = generate_getters(get_struct_fields(derive_input.clone())?)?;
+
+    Ok(quote! {
+        impl #struct_name {
+            #(#getters)*
+        }
+    })
+}
+
+fn generate_builder_struct(derive_input: DeriveInput) -> Result<TokenStream2, SynError> {
+    let builder_name = generate_builder_name(derive_input.clone());
+    let mut setters = Vec::new();
+    let mut field_names = Vec::new();
+
+    for field in get_struct_fields(derive_input.clone())?.iter() {
+        let field_name = field.ident.clone().unwrap();
+        let ty = field.ty.clone();
+
+        let setter_name = Ident::new(&format!("with_{}", field.ident.clone().unwrap().to_string()), Span::call_site());
+
+        setters.push(quote! {
+            pub fn #setter_name(mut self, value: #ty) -> Self {
+                self.#field_name = Some(value);
+                self
+            }
+        });
+
+        field_names.push(quote! {
+            #field_name: Option<#ty>
+        });
+    }
+
+    let build_impl = if has_gen_build_fn_attr(&derive_input.attrs) {
+        generate_build_impl(derive_input.clone())?
+    } else {
+        quote!()
+    };
+
+    Ok(quote! {
+        #[derive(Default, Clone)]
+        pub struct #builder_name {
+            #(#field_names), *
+        }
+
+        impl #builder_name {
+            pub fn new() -> Self {
+                #builder_name::default()
+            }
+
+            #(#setters)*
+        }
+
+        #build_impl
+    })
+}
+
+fn generate_build_impl(derive_input: DeriveInput) -> Result<TokenStream2, SynError> {
+
+    let struct_name = derive_input.ident.clone();
+    let builder_name = generate_builder_name(derive_input.clone());
+    let fields = get_struct_fields(derive_input.clone())?;
+    let mut let_stmts = Vec::new();
+    let mut field_names = Vec::new();
+
+    for field in fields.iter() {
+        let field_name = field.ident.clone().unwrap();
+
+        let let_stmt = if has_optional_attr(field) {
+            quote! {
+                let #field_name = self.#field_name.unwrap_or_default();
+            }
+        } else {
+            quote! {
+                let #field_name = self.#field_name.ok_or_else(|| BuilderError::MissingField(stringify!(#field_name).into()))?;
+            }
+        };
+
+        let_stmts.push(let_stmt);
+        field_names.push(field_name);
+    }
+
+    Ok(quote! {
+        impl Build for #builder_name {
+            type Result = Result<#struct_name, BuilderError>;
+
+            fn build(self) -> Self::Result {
+                #(#let_stmts)*
+
+                Ok(#struct_name {
+                    #(#field_names), *
+                })
+            }
+        }
+    })
+
+}
+
+fn get_struct_fields(derive_input: DeriveInput) -> Result<Fields, SynError> {
+    if let Data::Struct(d) = derive_input.data {
+        Ok(d.fields)
+    } else {
+        Err(SynError::new_spanned(derive_input.into_token_stream(), "builder is only compatible with stucts"))
+    }
+}
+
+fn generate_getters(fields: Fields) -> Result<Vec<TokenStream2>, SynError> {
+    let mut tokens = Vec::new();
+
+    for field in fields.iter().filter(|field| has_getter_attr(field)) {
+        let name = field.ident.clone().unwrap();
+        let ty = field.ty.clone();
+
+        if is_string(&ty) {
+            tokens.push(quote! {
+                pub fn #name(&self) -> &str {
+                    &self.#name
+                }
+            });
+        } else if is_vec(&ty) {
+            let ty = extract_type_from_generic(&ty)?; 
+            tokens.push(quote! {
+                pub fn #name(&self) -> &[#ty] {
+                    &self.#name
+                }
+            });
+        } else {
+            tokens.push(quote! {
+                pub fn #name(&self) -> &#ty {
+                    &self.#name
+                }
+            });
+        }
+    }
+
+    Ok(tokens)
+}
+
+fn has_getter_attr(field: &Field) -> bool {
+    has_helper_attribue(field, Ident::new("getter", Span::call_site()))
+}
+
+fn has_optional_attr(field: &Field) -> bool {
+    has_helper_attribue(field, Ident::new("optional", Span::call_site()))
+}
+
+fn has_helper_attribue(field: &Field, ident: Ident) -> bool {
+    field.attrs
+        .iter()
+        .filter_map(|attr| if let Ok(meta) = attr.parse_meta() {
+            Some(meta)
+        } else {
+            None
+        })
+        .any(|meta| meta.name() == ident)
+}
+
+fn is_string(ty: &Type) -> bool {
+    is_type(Ident::new("String", Span::call_site()), ty)
+}
+
+fn is_vec(ty: &Type) -> bool {
+    is_type(Ident::new("Vec", Span::call_site()), ty)
+}
+
+fn is_type(ident: Ident, ty: &Type) -> bool {
+    if let Type::Path(type_path) = ty {
+        type_path
+            .path
+            .segments
+            .iter()
+            .any(|x| x.ident == ident)
+    } else {
+        false
+    }
+}
+
+fn extract_type_from_generic(ty: &Type) -> Result<Type, SynError> {
+    let segment = if let Type::Path(type_path) = ty {
+        type_path
+            .path
+            .segments
+            .first()
+    } else {
+        return Err(SynError::new_spanned(ty.into_token_stream(), "Type does not have generic"));
+    };
+
+    let args = if let Some(seg) = segment {
+        seg.into_value().arguments.clone()
+    } else {
+        return Err(SynError::new_spanned(ty.into_token_stream(), "Type does not have generic"));
+    };
+
+    let angled_bracket_args =  if let PathArguments::AngleBracketed(args) = args {
+       if let Some(angled_bracket_args) = args.args.first() {
+          angled_bracket_args.into_value().clone()  
+       } else {
+        return Err(SynError::new_spanned(ty.into_token_stream(), "Type does not have generic"));
+       }
+    } else {
+        return Err(SynError::new_spanned(ty.into_token_stream(), "Type does not have generic"));
+    };
+
+    if let GenericArgument::Type(t) = angled_bracket_args {
+        Ok(t)
+    } else {
+        return Err(SynError::new_spanned(ty.into_token_stream(), "Type does not have generic"));
+    }
+}
+
+fn generate_builder_name(derive_input: DeriveInput) -> Ident {
+    for attr in derive_input.attrs {
+        if let Some(name) = extract_builder_name(&attr) {
+            return name;
+        } 
+    }
+
+    let struct_name = derive_input.ident.clone();
+
+    Ident::new(&format!("{}Builder", struct_name.to_string()), Span::call_site())
+}
+
+
+fn extract_builder_name(attr: &Attribute) -> Option<Ident> {
+    let segment = if let Some(segment) = attr.path.segments.first() {
+        segment
+    } else {
+        return None;
+    };
+
+    if segment.into_value().ident != Ident::new("builder_name", Span::call_site()) {
+        return None;
+    }
+
+    let meta_name_value = if let Ok(Meta::NameValue(nv)) = attr.parse_meta() {
+        nv
+    } else {
+        return None;
+    };
+
+    if let Lit::Str(s) = meta_name_value.lit {
+        Some(Ident::new(&s.value(), Span::call_site()))
+    } else {
+        None
+    }
+}
+
+fn has_gen_build_fn_attr(attrs: &[Attribute]) -> bool {
+    for attr in attrs {
+        let segment = if let Some(segment) = attr.path.segments.first() {
+                segment
+        } else {
+            return false;
+        };
+
+        if segment.into_value().ident == Ident::new("gen_build_impl", Span::call_site()) {
+            return true;
+        }
+    }
+
+    false
+}

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,0 +1,57 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![recursion_limit = "128"]
+extern crate proc_macro;
+
+mod builder;
+mod protos;
+
+use proc_macro::TokenStream;
+use builder::generate_builder_macro;
+use syn::{parse_macro_input, DeriveInput, ItemStruct};
+use protos::{generate_into_bytes_impl, generate_from_proto};
+use quote::quote;
+
+#[proc_macro_derive(Builder, attributes(builder_name, gen_build_impl, getter, optional))]
+pub fn derive_builder(item: TokenStream) -> TokenStream {
+
+    let derive_input = parse_macro_input!(item as DeriveInput);
+
+    generate_builder_macro(derive_input) 
+}
+
+#[proc_macro_derive(FromProtoImpl, attributes(proto_type, from_proto_impl, from_proto_impl_enum))]
+pub fn dervie_from_proto(item: TokenStream) -> TokenStream {
+    
+    let derive_input = parse_macro_input!(item as DeriveInput);
+
+    generate_from_proto(derive_input)
+        .map(|t| t.into())
+        .unwrap_or_else(|err| {
+            let compile_error = err.to_compile_error();
+            quote!(#compile_error).into()
+        })
+}
+
+#[proc_macro_attribute]
+pub fn impl_proto_into_bytes(_: TokenStream, item: TokenStream) -> TokenStream {
+
+    let parsed_item = item.clone();
+    let stct = parse_macro_input!(parsed_item as ItemStruct);
+
+    let into_bytes = generate_into_bytes_impl(stct);
+
+    into_bytes
+}

--- a/codegen/src/macros.rs
+++ b/codegen/src/macros.rs
@@ -1,0 +1,185 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+macro_rules! __gen_field {
+    ( $field:ident, req) => {
+        let $field = $field.ok_or_else(|| BuilderError::MissingField(stringify!($field).into()))?;
+    };
+    ($field:ident, opt) => {
+        let $field = $field.unwrap_or_default();
+    };
+}
+
+/// Creates struct and implemnts corresponding builder class
+///
+/// # Example Usage
+///
+/// ```rust
+///
+/// impl_struct_with_builder!(FinalizeRecordActionBuilder => FinalizeRecordAction {
+///     req record_id: String => &str,
+///     opt name: String => &str
+/// });
+/// ````
+///
+/// The above invocation will generate the following struct and builder
+///
+/// ```rust
+///
+/// #[derive(Default, Debug, Clone, PartialEq)]
+/// pub struct FinalizeRecordAction {
+///     record_id: String,
+///     name: String
+/// }
+///
+/// impl FinalizeRecordAction {
+///     # return values for getters are defined by `=> {type}`
+///     pub fn record_id(&self) -> &str {
+///         &self.record_id
+///     }
+///
+///     pub fn name(&self) -> &str {
+///         &self.name
+///     }
+/// }
+///
+/// #[derive(Default, Clone)]
+/// pub struct FinalizeRecordActionBuilder {
+///     record_id: Option<String>,
+///     name: Option<String>
+/// }
+///
+/// impl FinalizeRecordActionBuilder {
+///     pub fn new() -> Self {
+///        FinalizeRecordActionBuilder::default()
+///     }
+///
+///     pub fn record_id(mut self, value: &str) -> Self {
+///         self.record_id = Some(value);
+///         self
+///     }
+///
+///     pub fn name(mut self, value: &str) -> Self {
+///         self.name = Some(value);
+///         self
+///     }
+///
+///     pub fn build(self) -> Result<FianlizeRecordAction, BuilderError> {
+///
+///         # Requires field because `req` was set
+///         let record_id = self.record_id.ok_or_else(|| {
+///            BuilderError::MissingField("record_id".into())
+///        })?;
+///
+///        # Looks for default because `opt` was set
+///        let name = self.name.unwrap_or_default();
+///
+///        FinalizeRecordAction {
+///            record_id,
+///            name
+///        }
+///     }
+/// }
+/// ```
+///
+macro_rules! impl_struct_with_builder {
+    ($builder_name:ident => $struct_name:ident {
+        $($req:ident $field:ident: $type:ty => $getter_type:ty), *
+    }) => {
+        #[derive(Default, Debug, Clone, PartialEq)]
+        pub struct $struct_name {
+            $($field: $type), *
+        }
+
+        impl $struct_name {
+            $(pub fn $field(&self) -> $getter_type {
+                &self.$field
+            })*
+        }
+
+        #[derive(Default, Clone)]
+        pub struct $builder_name {
+            $($field: Option<$type>), *
+        }
+
+        impl $builder_name {
+            pub fn new() -> Self {
+                $builder_name::default()
+            }
+
+            $(pub fn $field(mut self, value: $type) -> Self {
+                self.$field = Some(value);
+                self
+            })*
+
+            pub fn build(self) -> Result<$struct_name, BuilderError> {
+                $(
+                    let $field = self.$field;
+                    __gen_field!($field, $req);
+                )*
+
+                Ok($struct_name {
+                    $($field), *
+                })
+            }
+        }
+    }
+}
+
+macro_rules! impl_from_bytes {
+    ($native:ident, $proto:path) => {
+        impl FromBytes<$native> for $native {
+            fn from_bytes(bytes: &[u8]) -> Result<$native, ProtoConversionError> {
+                let proto: $proto = protobuf::parse_from_bytes(bytes).map_err(|_| {
+                    ProtoConversionError::SerializationError(format!(
+                        "Unable to get {} from bytes",
+                        stringify!($native)
+                    ))
+                })?;
+
+                proto.into_native()
+            }
+        }
+    };
+}
+
+macro_rules! impl_into_bytes {
+    ($native:ident) => {
+        impl IntoBytes for $native {
+            fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+                let proto = self.into_proto()?;
+                let bytes = proto.write_to_bytes().map_err(|_| {
+                    ProtoConversionError::SerializationError(format!(
+                        "Unable to get {} from Bytes",
+                        stringify!($native)
+                    ))
+                })?;
+                Ok(bytes)
+            }
+        }
+    };
+}
+
+macro_rules! impl_into_proto {
+    ($native:ident, $proto:path) => {
+        impl IntoProto<$proto> for $native {}
+    };
+}
+
+macro_rules! impl_into_native {
+    ($native:ident, $proto:path) => {
+        impl IntoNative<$native> for $proto {}
+    };
+}
+

--- a/codegen/src/protos.rs
+++ b/codegen/src/protos.rs
@@ -1,0 +1,379 @@
+/*
+* Copyright 2018 Bitwise IO, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+* -----------------------------------------------------------------------------
+*/
+
+use proc_macro::{TokenStream};
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use syn::{Variant, Lit, GenericArgument, PathArguments, Type, Attribute, Data, Fields, Field, NestedMeta, Meta, Error as SynError, ItemStruct, Ident, parse::{Parse, ParseStream}, Result as ParseResult, DeriveInput};
+use quote::{quote, ToTokens};
+
+pub fn generate_into_bytes_impl(stct: ItemStruct) -> TokenStream {
+    let struct_name = stct.ident.clone();
+
+    return quote!{
+        #stct
+
+        impl IntoBytes for #struct_name {
+            fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+                let proto = self.into_proto()?;
+                let bytes = proto.write_to_bytes().map_err(|_| {
+                    ProtoConversionError::SerializationError(format!(
+                        "Unable to get {} from Bytes",
+                        stringify!(#struct_name)
+                    ))
+                })?;
+                Ok(bytes)
+            }
+        }
+    }.into();
+}
+
+pub fn generate_from_proto(derive_input: DeriveInput) -> Result<TokenStream2, SynError> {
+    match derive_input.clone().data {
+        Data::Struct(_) => generate_from_proto_for_struct(derive_input),
+        Data::Enum(_) => generate_from_proto_for_enum(derive_input),
+        _ => Err(
+            SynError::new_spanned(
+                derive_input.clone().into_token_stream(),
+                "Deriving from_proto is incompatible with this structure"))
+    }
+}
+
+fn generate_from_proto_for_struct(derive_input: DeriveInput) -> Result<TokenStream2, SynError> {
+    let struct_name = derive_input.ident.clone();
+    let generic_type = extract_proto_type(derive_input.clone())?;
+    let signature_type = generic_type.clone(); 
+    let fields = extract_proto_fields(derive_input.clone())?; 
+
+    Ok(quote! {
+        impl FromProto<#(#generic_type)*> for #struct_name {
+            fn from_proto(proto: #(#signature_type)*) -> Result<Self, ProtoConversionError> {
+                Ok(#struct_name {
+                    #(#fields),*
+                })
+            }
+        }
+    })
+}
+
+fn generate_from_proto_for_enum(derive_input: DeriveInput) -> Result<TokenStream2, SynError> {
+    let enum_name = derive_input.ident.clone();
+    let generic_type = extract_proto_type(derive_input.clone())?;
+    let signature_type = generic_type.clone(); 
+    let variants = get_enum_variants(derive_input.clone())?
+        .iter()
+        .map(|v| {
+            let ident = v.ident.clone();
+            quote!(#enum_name::#ident)
+        })
+        .collect::<Vec<TokenStream2>>();
+
+    let proto_variants = extract_proto_enum_variants(derive_input.clone())?
+        .iter()
+        .map(|variant| {
+            let generic_type = extract_proto_type(derive_input.clone())?;
+            Ok(quote!(#(#generic_type)*::#variant))
+        })
+        .collect::<Result<Vec<TokenStream2>, SynError>>()?;
+
+    Ok(quote! {
+        impl FromProto<#(#generic_type)*> for #enum_name {
+            fn from_proto(proto: #(#signature_type)*) -> Result<Self, ProtoConversionError> {
+                match proto {
+                    #(#proto_variants => Ok(#variants)),*
+                }
+            }
+        }
+    })
+}
+
+pub fn generate_into_from_bytes(proto_type: ProtoType) -> TokenStream {
+    return quote! {}.into();
+}
+
+fn extract_proto_type(derive_input: DeriveInput) -> Result<Vec<TokenStream2>, SynError> {
+    for attr in derive_input.clone().attrs {
+        let segment = if let Some(segment) = attr.path.segments.first() {
+            segment
+        } else {
+            continue;
+        };
+
+        if segment.into_value().ident != Ident::new("proto_type", Span::call_site()) {
+            continue;
+        }
+
+        let meta_name_value = if let Ok(Meta::NameValue(nv)) = attr.parse_meta() {
+            nv
+        } else {
+            continue;
+        };
+
+        if let Lit::Str(s) = meta_name_value.lit {
+            return Ok(path_to_token_stream(&s.value()));
+        } else {
+            continue;
+        }
+    }
+
+    Err(SynError::new_spanned(derive_input.clone().into_token_stream(),"A protobuf message type is required"))
+}
+
+fn extract_proto_fields(derive_input: DeriveInput) -> Result<Vec<TokenStream2>, SynError> {
+    let fields = get_struct_fields(derive_input.clone())?;
+
+    fields
+        .iter()
+        .map(make_proto_field_token_stream)
+        .collect::<Result<Vec<TokenStream2>, SynError>>()
+}
+
+fn extract_proto_enum_variants(derive_input: DeriveInput) -> Result<Vec<Ident>, SynError> {
+    let variants = get_enum_variants(derive_input.clone())?;
+
+    variants
+        .iter()
+        .map(make_proto_enum_variant)
+        .collect::<Result<Vec<Ident>, SynError>>()
+}
+
+fn make_proto_field_token_stream(field: &Field) -> Result<TokenStream2, SynError> {
+    for attr in field.attrs.clone() {
+        let meta = if let Ok(meta) = attr.parse_meta() {
+            meta
+        } else {
+            continue;
+        };
+
+        if meta.name() == Ident::new("from_proto_impl", Span::call_site()) {
+            return parse_proto_meta(field, &meta);
+        }
+    }
+
+    let field_name = field.ident.clone().unwrap();
+    let proto_getter_name = Ident::new(&format!("get_{}", field_name.to_string()), Span::call_site());
+
+    Ok(quote! {
+        #field_name: proto.#proto_getter_name()
+    })
+
+}
+
+fn make_proto_enum_variant(variant: &Variant) -> Result<Ident, SynError> {
+    for attr in variant.attrs.clone() {
+        let meta = if let Ok(meta) = attr.parse_meta() {
+            meta
+        } else {
+            continue;
+        };
+
+        if meta.name() != Ident::new("from_proto_impl_enum", Span::call_site()) {
+            continue;
+        }
+
+        let meta_list = if let Meta::List(l) = meta.clone() {
+            l.nested
+        } else {
+            return Err(SynError::new_spanned(meta.into_token_stream(), "Malformed Meta"));
+        };
+
+        let nested_meta = if let Some(pair) = meta_list.first() {
+            pair.into_value()
+        } else {
+            return Err(SynError::new_spanned(meta.clone().into_token_stream(), "Malformed Meta"));
+        };
+
+        if let NestedMeta::Meta(Meta::Word(i)) = nested_meta {
+            return Ok(i.clone());
+        } else {
+            return Err(SynError::new_spanned(meta.clone().into_token_stream(), "Malformed Meta"));
+        }
+    }
+
+    Err(SynError::new_spanned(variant.clone().into_token_stream(),
+    "No protobuf vairant specified"))
+}
+
+fn parse_proto_meta(field: &Field, meta: &Meta) -> Result<TokenStream2, SynError> {
+
+    let meta_list = if let Meta::List(l) = meta {
+        l.nested.first()
+    } else {
+        return Err(SynError::new_spanned(meta.into_token_stream(), "Malformed Meta"));
+    };
+
+    let nested_meta = if let Some(pair) = meta_list {
+        pair.into_value()
+    } else {
+        return Err(SynError::new_spanned(meta.into_token_stream(), "Malformed Meta"));
+    };
+
+    let ident = if let NestedMeta::Meta(Meta::Word(i)) = nested_meta {
+        i.clone()
+    } else {
+        return Err(SynError::new_spanned(meta.into_token_stream(), "Malformed Meta"));
+    };
+
+    let field_name = field.ident.clone().unwrap();
+    let proto_getter_name = Ident::new(&format!("get_{}", field_name.to_string()), Span::call_site());
+
+    let token = if ident  == Ident::new("to_string", Span::call_site()) {
+        quote! {
+            #field_name: proto.#proto_getter_name().to_string()
+        }
+    } else if ident  == Ident::new("clone", Span::call_site()) {
+        quote! {
+            #field_name: proto.#proto_getter_name().clone()
+        }
+    } else if ident  == Ident::new("from_proto", Span::call_site()) {
+        let ty = field.ty.clone();
+        quote! {
+            #field_name: #ty::from_proto(proto.#proto_getter_name().clone())?
+        }
+    } else if ident  == Ident::new("Vec", Span::call_site()) {
+        let vec_ty = field.ty.clone();
+        let ty = extract_type_from_generic(&vec_ty)?;
+
+        if is_string(&ty) {
+            quote! {
+                #field_name: proto
+                .#proto_getter_name()
+                .to_vec()
+                .into_iter()
+                .map(String::from)
+                .collect()
+            }
+        } else {
+            quote! {
+                #field_name: proto
+                .#proto_getter_name()
+                .to_vec()
+                .into_iter()
+                .map(#ty::from_proto)
+                .collect::<Result<#vec_ty, ProtoConversionError>>()?
+            }
+        }
+    } else {
+        return Err(SynError::new_spanned(meta.into_token_stream(), "Unknown from_impl directive"));
+    };
+
+    Ok(token)
+}
+
+fn is_string(ty: &Type) -> bool {
+    is_type(Ident::new("String", Span::call_site()), ty)
+}
+
+fn is_type(ident: Ident, ty: &Type) -> bool {
+    if let Type::Path(type_path) = ty {
+        type_path
+            .path
+            .segments
+            .iter()
+            .any(|x| x.ident == ident)
+    } else {
+        false
+    }
+}
+
+fn get_struct_fields(derive_input: DeriveInput) -> Result<Fields, SynError> {
+    if let Data::Struct(d) = derive_input.data {
+        Ok(d.fields)
+    } else {
+        Err(SynError::new_spanned(derive_input.into_token_stream(), "macro is only compatible with stucts"))
+    }
+}
+
+fn get_enum_variants(derive_input: DeriveInput) -> Result<Vec<Variant>, SynError> {
+    let enm = if let Data::Enum(e) = derive_input.data {
+        e
+    } else {
+        return Err(
+            SynError::new_spanned(
+                derive_input.into_token_stream(),
+                "macro is only compatible with enums"));
+    };
+
+    Ok(
+        enm
+        .variants
+        .into_iter()
+        .collect::<Vec<Variant>>())
+}
+
+pub struct ProtoType {
+    //proto_type: Ident,
+}
+
+impl Parse for ProtoType {
+    fn parse(input: ParseStream) -> ParseResult<Self> {
+        let lookahead = input.lookahead1();
+        println!("{:#?}", input);
+        Ok(ProtoType {
+        })
+    }
+}
+
+fn extract_type_from_generic(ty: &Type) -> Result<Type, SynError> {
+    let segment = if let Type::Path(type_path) = ty {
+        type_path
+            .path
+            .segments
+            .first()
+    } else {
+        return Err(SynError::new_spanned(ty.into_token_stream(), "Type does not have generic"));
+    };
+
+    let args = if let Some(seg) = segment {
+        seg.into_value().arguments.clone()
+    } else {
+        return Err(SynError::new_spanned(ty.into_token_stream(), "Type does not have generic"));
+    };
+
+    let angled_bracket_args =  if let PathArguments::AngleBracketed(args) = args {
+       if let Some(angled_bracket_args) = args.args.first() {
+          angled_bracket_args.into_value().clone()  
+       } else {
+        return Err(SynError::new_spanned(ty.into_token_stream(), "Type does not have generic"));
+       }
+    } else {
+        return Err(SynError::new_spanned(ty.into_token_stream(), "Type does not have generic"));
+    };
+
+    if let GenericArgument::Type(t) = angled_bracket_args {
+        Ok(t)
+    } else {
+        return Err(SynError::new_spanned(ty.into_token_stream(), "Type does not have generic"));
+    }
+}
+
+fn path_to_token_stream(path: &str) -> Vec<TokenStream2> {
+    let mut tokens = Vec::new();
+
+    for seg in path.split("::") {
+        let ident = Ident::new(seg, Span::call_site());
+
+        tokens.push(quote!(#ident));
+        tokens.push(quote!(::));
+    }
+
+    // Remove extra "::"
+    if !tokens.is_empty() {
+        tokens.pop();
+    }
+
+    tokens
+}

--- a/codegen/tests/builder.rs
+++ b/codegen/tests/builder.rs
@@ -1,0 +1,150 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use codegen::Builder;
+
+#[derive(Debug, PartialEq)]
+pub enum BuilderError {
+    MissingField(String),
+}
+
+impl std::fmt::Display for BuilderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            BuilderError::MissingField(ref s) => write!(f, "MissingField: {}", s),
+        }
+    }
+}
+
+pub trait Build {
+    type Result;
+
+    fn build(self) -> Self::Result;
+}
+
+#[derive(Builder, Debug)]
+#[gen_build_impl]
+pub struct Agent {
+
+    #[getter]
+    public_key: String,
+
+    #[getter]
+    wears_crocks: bool,
+
+    #[getter]
+    known_enemies: Vec<String>,
+
+    #[getter]
+    #[optional]
+    role: String
+}
+
+#[derive(Builder, Debug)]
+#[gen_build_impl]
+#[builder_name = "OrgBuilder"]
+pub struct Organization {
+    #[getter]
+    org_id: String
+}
+
+#[derive(Builder)]
+pub struct Payload {
+
+    #[getter]
+    action: String,
+
+    #[getter]
+    payload: Vec<u8>
+}
+
+impl Build for PayloadBuilder {
+    type Result = Result<Payload, BuilderError>;
+
+    fn build(self) -> Self::Result {
+        Ok(Payload {
+            action: "EMPTY".to_string(),
+            payload: Vec::new()
+        })
+    }
+}
+
+#[test]
+fn test_agent_builder() {
+    let builder = AgentBuilder::new()
+        .with_public_key("wut1234".into())
+        .with_wears_crocks(false)
+        .with_role("admin".into())
+        .with_known_enemies(vec!["tim".to_string(), "jimmy".to_string()]);
+
+    let agent = builder.build().unwrap();
+
+    assert_eq!("wut1234", agent.public_key());
+    assert_eq!(false, *agent.wears_crocks());
+    assert_eq!(&["tim".to_string(), "jimmy".to_string()], agent.known_enemies());
+    assert_eq!("admin", agent.role());
+}
+
+#[test]
+fn test_agent_builder_optional_field() {
+    let builder = AgentBuilder::new()
+        .with_public_key("wut1234".into())
+        .with_wears_crocks(false)
+        .with_known_enemies(vec!["tim".to_string(), "jimmy".to_string()]);
+
+    let agent = builder.build().unwrap();
+
+    assert_eq!("wut1234", agent.public_key());
+    assert_eq!(false, *agent.wears_crocks());
+    assert_eq!(&["tim".to_string(), "jimmy".to_string()], agent.known_enemies());
+    assert_eq!("", agent.role());
+}
+
+#[test]
+fn test_agent_builder_error_on_required_field() {
+    let builder = AgentBuilder::new()
+        .with_wears_crocks(false)
+        .with_known_enemies(vec!["tim".to_string(), "jimmy".to_string()]);
+
+    let agent_result = builder.build();
+
+    assert!(agent_result.is_err());
+
+    let expected_err = BuilderError::MissingField("public_key".to_string());
+
+    let err = agent_result.unwrap_err();
+
+    assert_eq!(expected_err, err);
+}
+
+#[test]
+fn test_custom_builder_name() {
+    let org = OrgBuilder::new()
+        .with_org_id("rywerx1234".into())
+        .build()
+        .unwrap();
+
+    assert_eq!("rywerx1234", org.org_id());
+}
+
+#[test]
+fn test_custom_build() {
+    let payload = PayloadBuilder::new()
+        .with_action("CreateAgent".into())
+        .with_payload(Vec::new())
+        .build()
+        .unwrap();
+
+    assert_eq!("EMPTY", payload.action());
+}

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -24,6 +24,7 @@ libc = ">=0.2.35"
 openssl = "0.10"
 uuid = { version = "0.7", features = ["v4"] }
 sawtooth-sdk = { version = "0.3", optional = true }
+codegen = { path = "../codegen" }
 
 [dev-dependencies]
 rand_hc = "0.1"

--- a/libtransact/build.rs
+++ b/libtransact/build.rs
@@ -38,6 +38,7 @@ fn main() {
             proto_path.join("batch.proto").to_str().unwrap(),
             proto_path.join("transaction.proto").to_str().unwrap(),
             proto_path.join("events.proto").to_str().unwrap(),
+            proto_path.join("processor.proto").to_str().unwrap(),
             proto_path
                 .join("transaction_receipt.proto")
                 .to_str()
@@ -52,6 +53,6 @@ fn main() {
     // Create mod.rs accordingly
     let mut mod_file = File::create(dest_path.join("mod.rs")).unwrap();
     mod_file
-        .write_all(b"pub mod batch;\npub mod events;\npub mod transaction;\npub mod transaction_receipt;\npub mod merkle;\n")
+        .write_all(b"pub mod batch;\npub mod events;\npub mod transaction;\npub mod transaction_receipt;\npub mod merkle;\npub mod processor;\n")
         .unwrap();
 }

--- a/libtransact/protos/processor.proto
+++ b/libtransact/protos/processor.proto
@@ -1,0 +1,149 @@
+// Copyright 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "processor_pb2";
+
+import "transaction.proto";
+
+
+// The registration request from the transaction processor to the
+// validator/executor.
+//
+// The protocol_version field is used to check if the validator supports
+// requested features by a transaction processor.
+// Following are the versions supported:
+//     1    Transaction processor can request for either raw header bytes or
+//          deserialized TransactionHeader field in the TpProcessRequest
+//          message. The default option is set to send deserialized
+//          TransactionHeader.
+message TpRegisterRequest {
+    // enum used to fill in transaction header field in TpProcessRequest.
+    // This field can be set before transaction processor registers with
+    // validator.
+    enum TpProcessRequestHeaderStyle {
+        HEADER_STYLE_UNSET = 0;
+        EXPANDED = 1;
+        RAW = 2;
+    }
+
+    // A settled upon name for the capabilities of the transaction processor.
+    // For example: intkey, xo
+    string family = 1;
+
+    // The version supported.  For example:
+    //      1.0  for version 1.0
+    //      2.1  for version 2.1
+    string version = 2;
+
+    // The namespaces this transaction processor expects to interact with
+    // when processing transactions matching this specification; will be
+    // enforced by the state API on the validator.
+    repeated string namespaces = 4;
+
+    // The maximum number of transactions that this transaction processor can
+    // handle at once.
+    uint32 max_occupancy = 5;
+
+    // Validator can make use of this field to check if the requested features
+    // are supported. Registration requests can be either accepted or rejected
+    // based on this field.
+    uint32 protocol_version = 6;
+
+    // Setting it to RAW, validator would fill in serialized transaction header
+    // when sending TpProcessRequest to the transaction processor.
+    TpProcessRequestHeaderStyle request_header_style = 7;
+}
+
+// A response sent from the validator to the transaction processor
+// acknowledging the registration
+message TpRegisterResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        ERROR = 2;
+    }
+
+    Status status = 1;
+
+    // Respond back with protocol_version, the value that can be used by SDK to
+    // know if validator supports expected feature.
+    uint32 protocol_version = 2;
+}
+
+// The unregistration request from the transaction processor to the
+// validator/executor. The correct handlers are determined from the
+// zeromq identity of the tp, on the validator side.
+message TpUnregisterRequest {
+
+}
+
+// A response sent from the validator to the transaction processor
+// acknowledging the unregistration
+message TpUnregisterResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        ERROR = 2;
+    }
+
+    Status status = 1;
+}
+
+
+// The request from the validator/executor of the transaction processor
+// to verify a transaction.
+message TpProcessRequest {
+    // The de-serialized transaction header from client request
+    TransactionHeader header = 1;
+
+    // The transaction payload
+    bytes payload = 2;
+
+    // The transaction header_signature
+    string signature = 3;
+
+    // The context_id for state requests.
+    string context_id = 4;
+
+    // The serialized header as received by client.
+    // Controlled by a flag during transaction processor registration.
+    bytes header_bytes = 5;
+}
+
+
+// The response from the transaction processor to the validator/executor
+// used to respond about the validity of a transaction
+message TpProcessResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        INVALID_TRANSACTION = 2;
+        INTERNAL_ERROR = 3;
+    }
+
+    Status status = 1;
+
+    // A message to include on responses in the cases where
+    // status is either INVALID_TRANSACTION or INTERNAL_ERROR
+    string message = 2;
+
+    // Information that may be included with the response.
+    // This information is an opaque, application-specific encoded block of
+    // data that will be propagated back to the transaction submitter.
+    bytes extended_data = 3;
+}

--- a/libtransact/src/protocol/builder.rs
+++ b/libtransact/src/protocol/builder.rs
@@ -1,0 +1,19 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub trait Build {
+    type Result;
+
+    fn build(self) -> Self::Result;
+}

--- a/libtransact/src/protocol/errors.rs
+++ b/libtransact/src/protocol/errors.rs
@@ -1,0 +1,32 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Debug, PartialEq)]
+pub enum BuilderError {
+    MissingField(String),
+}
+
+impl std::fmt::Display for BuilderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            BuilderError::MissingField(ref s) => write!(f, "MissingField: {}", s),
+        }
+    }
+}
+
+pub trait Build {
+    type Result;
+
+    fn build(self) -> Self::Result;
+}

--- a/libtransact/src/protocol/mod.rs
+++ b/libtransact/src/protocol/mod.rs
@@ -19,7 +19,11 @@
 //!
 //! These structs cover the core protocols of the Transact system.  Batches of transactions are
 //! scheduled and executed.  The resuls of execution are stored in transaction receipts.
+extern crate codegen;
 
 pub mod batch;
 pub mod receipt;
 pub mod transaction;
+pub mod errors;
+pub mod builder;
+pub mod validator;

--- a/libtransact/src/protocol/validator.rs
+++ b/libtransact/src/protocol/validator.rs
@@ -1,0 +1,82 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::protocol::codegen::{impl_proto_into_bytes, Builder, FromProtoImpl};
+use crate::protocol::errors::BuilderError;
+use crate::protocol::builder::Build;
+use crate::protos;
+use crate::protos::{
+    FromBytes, FromNative, FromProto, IntoBytes, IntoNative, IntoProto, ProtoConversionError,
+};
+
+
+//enum MessageType {
+    //TpRegisterRequest,
+    //TpRegisterResponse,
+    //TpUnregisterRequest,
+    //TpUnregisterResponse,
+    //TpProcessRequest,
+    //TpProcessResponse,
+    //TpStateGetRequest,
+    //TpStateGetResponse,
+    //TpStateSetRequest,
+    //TpStateSetResponse,
+    //TpStateDeleteRequest,
+    //TpStateDeleteResponse,
+    //TpReceiptAddDataRequest,
+    //TpReceiptAddDataResponse,
+    //TpEventAddRequest,
+    //TpEventAddResponse
+//}
+
+#[derive(FromProtoImpl, Debug, Clone)]
+#[proto_type = "protos::processor::TpRegisterRequest_TpProcessRequestHeaderStyle"]
+pub enum TpProcessRequestHeaderStyle {
+    #[from_proto_impl_enum(HEADER_STYLE_UNSET)]
+    HeaderStyleUnset,
+
+    #[from_proto_impl_enum(EXPANDED)]
+    Expanded,
+
+    #[from_proto_impl_enum(RAW)]
+    Raw,
+}
+
+#[derive(Builder, FromProtoImpl, Debug)]
+#[gen_build_impl]
+#[proto_type = "protos::processor::TpRegisterRequest"]
+pub struct TpRegisterRequest {
+
+    #[getter]
+    #[from_proto_impl(to_string)]
+    family: String,
+
+    #[getter]
+    #[from_proto_impl(to_string)]
+    version: String,
+
+    #[getter]
+    #[from_proto_impl(Vec)]
+    namespaces: Vec<String>,
+
+    #[getter]
+    max_occupancy: u32,
+
+    #[getter]
+    protocol_version: u32,
+
+    #[getter]
+    #[from_proto_impl(from_proto)]
+    request_header_style: TpProcessRequestHeaderStyle
+}


### PR DESCRIPTION
Adds macros for generating protocols.

### Macros currently implemented:

* `Builder`
* `FromProtoImpl`
*  `impl_proto_into_bytes` (partial)

### Macros to be implemented before PR:

* `FromNativeImpl`
* `impl_proto_from_bytes`
* `IntoNative`
* `IntoProto`

### Other TODOs

* Documentation
* Linting/ running clippy
* Clean up commit history

### Example

libtransact/src/protocol/validator.rs

```
#[derive(FromProtoImpl, Debug, Clone)]
#[proto_type = "protos::processor::TpRegisterRequest_TpProcessRequestHeaderStyle"]
pub enum TpProcessRequestHeaderStyle {
    #[from_proto_impl_enum(HEADER_STYLE_UNSET)]
    HeaderStyleUnset,

    #[from_proto_impl_enum(EXPANDED)]
    Expanded,

    #[from_proto_impl_enum(RAW)]
    Raw,
}

#[derive(Builder, FromProtoImpl, Debug)]
#[gen_build_impl]
#[proto_type = "protos::processor::TpRegisterRequest"]
pub struct TpRegisterRequest {

    #[getter]
    #[from_proto_impl(to_string)]
    family: String,

    #[getter]
    #[from_proto_impl(to_string)]
    version: String,

    #[getter]
    #[from_proto_impl(Vec)]
    namespaces: Vec<String>,

    #[getter]
    max_occupancy: u32,

    #[getter]
    protocol_version: u32,

    #[getter]
    #[from_proto_impl(from_proto)]
    request_header_style: TpProcessRequestHeaderStyle
}
```


